### PR TITLE
add optional support for mineclonia

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,6 +1,6 @@
 name = safe_chest
 title = Safe Chest
 author = Atlante
-depends = default
-optional_depends = 
+depends = 
+optional_depends = default, mcl_core
 description = Add a safe chest with secret password


### PR DESCRIPTION
Fixes #1.

I noticed your code had inventory size 32, which sounded like you wanted 4 rows so I put that in the Mineclonia formspec. However, I did not make any changes to the Minetest Game formspec which only shows me 3 rows even though the inventory has room for a fourth row.

I added a redstone block to the recipe for Mineclonia, just to make it feel like it has electronics or something. If a player has enough iron for 2 iron blocks, he'll have plenty of redstone dust too. If you don't like the recipe, feel free to adjust!